### PR TITLE
Add 'vildt' interpretation

### DIFF
--- a/resource/giphys.md
+++ b/resource/giphys.md
@@ -88,6 +88,10 @@
 
 ![Vegan](https://media.giphy.com/media/54Y38YdCPe58XA0FpJ/giphy-downsized.gif)
 
+# Venison
+
+![Venison](https://media.giphy.com/media/CYu6DJXVazUL8wxxUz/giphy-downsized.gif)
+
 # Five minute warning
 
 ![FiveMin](https://media.giphy.com/media/hVP3ippY6MdtJ2Yd3X/giphy-downsized.gif)

--- a/src/util.ts
+++ b/src/util.ts
@@ -21,6 +21,8 @@ export function convertIcon(iconText: string): string {
       return ':fish:';
     case 'Kalkun':
       return ':turkey:';
+    case 'Vildt':
+      return ':deer:';
     default:
       return ':broccoli:';
   }
@@ -95,6 +97,8 @@ export function getRandomGifLink(type: string): string {
   let theme = type.length > 0 ? type.toLocaleLowerCase() : 'notheme';
   if (theme === ':broccoli:') {
     theme = 'vegan';
+  } else if (theme === ':deer:') {
+    theme = 'venison';
   }
 
   const mdFile = readFileSync('resource/giphys.md').toString();


### PR DESCRIPTION
ISS introduced a new game meat icon; 'vildt'. Ensure that we properly translate that with icon and GIFs.

- Use ':deer:' icon when ISS indicates 'vildt'
- Add an inital GIF for the venison category.

resolves #15